### PR TITLE
Add github action to automatically publish package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,22 @@
+name: "Publish NPM package"
+
+on:
+  pull_request:
+    branches: 
+      - main
+    types: [closed]
+
+jobs:
+  if_merged:
+    if: startsWith(github.event.pull_request.title, 'Bump Package Version') && github.event.pull_request.merged == true 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
- Add github action to publish CLI package
- The workflow will trigger when any PR that starts with title `Bump Package Version` and is merged to main
- Add NPM_AUTH_TOKEN in the repository secret (Go to repo settings > Secrets > Actions > New Repository Secret)