### PR TITLE
Specify node version in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
         "nextjs",
         "frontend"
     ],
+    "engines": {
+        "node": ">=15"
+    },
     "author": "Madhav Bhasin <madhav.bhasin@devslane.com>",
     "license": "ISC",
     "repository": {


### PR DESCRIPTION
Changes : 
- Add `engines` in package.json to specify node version to use with CLI package
- Add `.npmrc` to throw error with invalid node version 

This will fix : 
- #4 
- #5 